### PR TITLE
Added TextToImagePublisher for hsrb head display

### DIFF
--- a/src/pycram/utilities/robocup_utils.py
+++ b/src/pycram/utilities/robocup_utils.py
@@ -180,6 +180,21 @@ class TextToSpeechPublisher():
                     break
 
                     
+class TextToImagePublisher:
+    def __init__(self, topic='/text_to_image', queue_size=10):
+        """
+        Initializes the TextToImagePublisher with a ROS publisher.
+
+        :param topic: The ROS topic to publish text to generate an image. Default is '/text_to_image'.
+        :param queue_size: The size of the message queue for the publisher. Default is 10.
+        """
+        self.pub = rospy.Publisher(topic, String, queue_size=queue_size, latch=True)
+
+    def pub_now(self, text):
+        self.pub.publish(text)
+
+        loginfo(f"Image generated for: {text}")
+
 
 class ImageSwitchPublisher:
     """


### PR DESCRIPTION
Adds a publisher for converting text into an image that can be used for the hsrb head display.


- Depends on TextToImageSubscriber which needs to be available  and running on hsrb. 
  - Currently located in "/hsr-hmi/Desktop/display/text_to_image.py"
  - Images are overwritten after each use and will be saved on the hsrb in the folder "/tmp/image_publisher"
  - Directory "image_publisher" will be created if it does not exist.