### PR TITLE
[head_display] added enum for image that is generated with text

### DIFF
--- a/src/pycram/datastructures/enums.py
+++ b/src/pycram/datastructures/enums.py
@@ -181,6 +181,7 @@ class ImageEnum(Enum):
     SOFA = 17
     INSPECT = 18
     CHAIR = 37
+    GENERATED_TEXT = 40
 
 
 class VirtualMobileBaseJointName(Enum):


### PR DESCRIPTION
This image needs to be generated at first, as it is located in hsrbs tmp folder.

To generate an image this way. it is required to either use the TextToImagePublisher or manually publish onto the topic "/text_to_image"